### PR TITLE
getSize was returning null in some cases

### DIFF
--- a/infiniteScrollView.js
+++ b/infiniteScrollView.js
@@ -23,7 +23,7 @@ define(function(require, exports, module) {
         var node = this._node;
         this.contentSize = 0;
         for(var i in node._.array) {
-            this.contentSize += node._.array[i].getSize()[1];
+            this.contentSize += node._.array[i].size[1];
         }
     }
 


### PR DESCRIPTION
Don't know why, but sometimes getSize() returns null... changing to 'size' fixed it for me
Maybe it was caused by surface with size set to [undefined, true]
